### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run `cmake` to configure things.
     cmake . \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DQt5Widgets_DIR=/opt/homebrew/opt/qt5/lib/cmake/Qt5Widgets
+        -DQt5Widgets_DIR=/opt/homebrew/opt/qt@5/lib/cmake/Qt5Widgets
 
 Export `LIBRARY_PATH` environment variable pointing to Homebrew `lib` folder, to avoid linking issues.
 


### PR DESCRIPTION
After running

 cmake . \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=/usr/local \
    -DQt5Widgets_DIR=/opt/homebrew/opt/qt5/lib/cmake/Qt5Widgets

I found the error in console:

CMake Error at heimdall-frontend/CMakeLists.txt:11 (find_package):
  By not providing "FindQt5Widgets.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "Qt5Widgets", but CMake did not find one.

  Could not find a package configuration file provided by "Qt5Widgets" with
  any of the following names:

    Qt5WidgetsConfig.cmake
    qt5widgets-config.cmake

  Add the installation prefix of "Qt5Widgets" to CMAKE_PREFIX_PATH or set
  "Qt5Widgets_DIR" to a directory containing one of the above files.  If
  "Qt5Widgets" provides a separate development package or SDK, be sure it has
  been installed.

This fix are helped me to finish this step.
-- Found ZLIB: /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libz.tbd (found version "1.2.12") -- Configuring done (0.3s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/iharkarotki/Downloads/Heimdall